### PR TITLE
Fix coursework typo

### DIFF
--- a/client/src/components/Education.tsx
+++ b/client/src/components/Education.tsx
@@ -72,7 +72,7 @@ const courseWorkUTD: CourseWork[] = [
     { name: "Big Data & Data Science", icon: "fas fa-database" },
     { name: "Python Programming", icon: "fas fa-chart-line" },
     { name: "C Programming", icon: "fas fa-cloud" },
-    { name: "Obeject Oriented Programming", icon: "fas fa-chart-bar" },
+    { name: "Object Oriented Programming", icon: "fas fa-chart-bar" },
     { name: "Web Programming", icon: "fas fa-calculator" },
     { name: "Data Structures using C++", icon: "fas fa-chart-line" },
     { name: "Cloud Computing", icon: "fas fa-cloud" },


### PR DESCRIPTION
## Summary
- fix typo in `courseWorkREVA` so "Object Oriented Programming" is spelled correctly

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6864125d08b4833088822f2c20c4e541