### PR TITLE
Add basic storage tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist/public"
+    "deploy": "gh-pages -d dist/public",
+    "test": "node --test"
   },
   "homepage": "https://xploit007.github.io/portfolio/",
   "dependencies": {

--- a/server/__tests__/storage.test.js
+++ b/server/__tests__/storage.test.js
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { MemStorage } from '../storage.js';
+
+function createStorage() {
+  return new MemStorage();
+}
+
+test('createUser assigns incremental IDs and stores the user', async () => {
+  const storage = createStorage();
+  const user1 = await storage.createUser({ username: 'alice', password: 'pw1' });
+  const user2 = await storage.createUser({ username: 'bob', password: 'pw2' });
+
+  assert.equal(user1.id, 1);
+  assert.equal(user2.id, 2);
+  assert.deepEqual(await storage.getUser(1), user1);
+  assert.deepEqual(await storage.getUser(2), user2);
+});
+
+test('getUser retrieves users by ID', async () => {
+  const storage = createStorage();
+  const user = await storage.createUser({ username: 'charlie', password: 'pw' });
+  const fetched = await storage.getUser(user.id);
+  assert.deepEqual(fetched, user);
+});
+
+test('getUserByUsername finds users by username', async () => {
+  const storage = createStorage();
+  const user = await storage.createUser({ username: 'dave', password: 'pw' });
+  const fetched = await storage.getUserByUsername('dave');
+  assert.deepEqual(fetched, user);
+});

--- a/server/storage.js
+++ b/server/storage.js
@@ -1,0 +1,25 @@
+export class MemStorage {
+  constructor() {
+    this.users = new Map();
+    this.currentId = 1;
+  }
+
+  async getUser(id) {
+    return this.users.get(id);
+  }
+
+  async getUserByUsername(username) {
+    return Array.from(this.users.values()).find(
+      (user) => user.username === username,
+    );
+  }
+
+  async createUser(insertUser) {
+    const id = this.currentId++;
+    const user = { ...insertUser, id };
+    this.users.set(id, user);
+    return user;
+  }
+}
+
+export const storage = new MemStorage();


### PR DESCRIPTION
## Summary
- add a compiled JS version of the storage module for running tests
- create tests validating `MemStorage` behaviour
- expose a `test` npm script using Node's built‑in test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864125f2718833092366fa4767226d4