### PR TITLE
Fix chatbot welcome message styling

### DIFF
--- a/client/src/components/ChatBot.tsx
+++ b/client/src/components/ChatBot.tsx
@@ -236,10 +236,9 @@ export default function ChatBot() {
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 10 }}
-            className="absolute right-20 bottom-0 mb-3 bg-slate-700 text-white px-3 py-2 rounded-full shadow-lg flex items-center gap-2"
+            className="absolute right-20 bottom-0 mb-3 bg-slate-700 text-white px-3 py-2 rounded-lg shadow-lg"
           >
-            <i className="fas fa-comment-dots" />
-            <span className="text-sm">Hi! Need help?</span>
+            <span className="text-sm">Hi! How can I help you?</span>
           </motion.div>
         )}
       </AnimatePresence>


### PR DESCRIPTION
## Summary
- simplify the chat welcome tooltip styling
- show a text-only message without icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686462b6eac483309db853c8c9a8150e