### PR TITLE
Fix chat bot failing on missing OpenAI API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,9 @@
 import express, { type Request, Response, NextFunction } from "express";
+import dotenv from "dotenv";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+
+dotenv.config();
 
 const app = express();
 app.use(express.json());

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -63,7 +63,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // use storage to perform CRUD operations on the storage interface
   // e.g. storage.insertUser(user) or storage.getUserByUsername(username)
 
-  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not set");
+  }
+  const openai = new OpenAI({ apiKey });
 
   app.post("/api/chat", async (req: Request, res: Response) => {
     const message: string | undefined = req.body?.message;
@@ -82,6 +86,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const response = completion.choices[0]?.message?.content || "";
       res.json({ message: response });
     } catch (err) {
+      console.error("OpenAI request failed", err);
       res.status(500).json({ message: "Failed to fetch response" });
     }
   });


### PR DESCRIPTION
## Summary
- load environment variables with `dotenv`
- handle missing `OPENAI_API_KEY` in the server
- log OpenAI request errors for debugging
- provide `.env.example` template

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68657048d0f483308fbc4d0cd968b864