### PR TITLE
Fix emotion API path on GitHub pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist
 .DS_Store
 server/public
 vite.config.ts.*
-*.tar.gz.env
+*.tar.gz
+server/emotion_models/

--- a/attached_assets/Emotion_Detection_from_Text.ipynb
+++ b/attached_assets/Emotion_Detection_from_Text.ipynb
@@ -236,7 +236,7 @@
         }
       ],
       "source": [
-        "df = pd.read_csv('text_emotions.csv')\n",
+        "df = pd.read_csv('emotion_dataset.csv')\n",
         "df"
       ]
     },

--- a/client/src/components/ChatBot.tsx
+++ b/client/src/components/ChatBot.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import ChatbotICON from "../resources/chatbot-logo.png";
+import { apiUrl } from "@/lib/utils";
 
 interface Message {
   id: string;
@@ -56,11 +57,14 @@ export default function ChatBot() {
   const sendMessage = async (text: string) => {
     addMessage(text);
     try {
-      const res = await fetch("/api/chat", {
+      const res = await fetch(apiUrl("/api/chat"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: text }),
       });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
       const data = await res.json();
       if (data?.message) {
         addMessage(data.message, true);

--- a/client/src/components/Projects.tsx
+++ b/client/src/components/Projects.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import AnimatedSection from "./AnimatedSection";
+import { apiUrl } from "@/lib/utils";
 
 const EMOTIONS = ["sadness", "joy", "love", "anger", "fear", "surprise"] as const;
 const EMOJI_MAP: Record<string, string> = {
@@ -32,11 +33,14 @@ function EmotionDemo() {
     setPredicted(null);
     setRating(0);
     try {
-      const res = await fetch("/api/emotion", {
+      const res = await fetch(apiUrl("/api/emotion"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text }),
       });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
       const data = await res.json();
       if (data && data.label) {
         setResults({ [data.label]: 1 });

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -87,3 +87,10 @@ export const slugify = (text: string) => {
     .replace(/\s+/g, '-')
     .replace(/-+/g, '-');
 };
+
+// Build API URL respecting the app base path
+export const apiUrl = (endpoint: string) => {
+  const base = import.meta.env.BASE_URL || '/';
+  const prefix = base === '/' ? '' : base.replace(/\/$/, '');
+  return `${prefix}${endpoint.startsWith('/') ? endpoint : '/' + endpoint}`;
+};


### PR DESCRIPTION
## Summary
- ensure prebuilt emotion models stay out of git
- add `apiUrl` helper that prefixes the gh-pages base path
- update emotion and chat fetch calls to use `apiUrl`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6865eee61aa4833099386db96dcf7e08