### PR TITLE
Add demo button for emotion detection project

### DIFF
--- a/client/src/components/Projects.tsx
+++ b/client/src/components/Projects.tsx
@@ -29,6 +29,7 @@ interface Project {
   keyMetric?: string;
   modelPerformance?: { model: string; accuracy: string }[];
   previewUrl?: string;
+  demoUrl?: string;
 }
 
 export default function Projects() {
@@ -52,6 +53,7 @@ export default function Projects() {
       ],
       technologies: ["Python", "Hugging Face", "Streamlit", "NLP", "Real-Time Analytics"],
       secondaryCTA: { text: "GitHub", link: "https://github.com/xploit007/Credit-Risk" },
+      demoUrl: "https://xploit-emotion-detection.streamlit.app/",
       badge: { text: "Demo", variant: "default", color: "bg-green-100 text-green-800" },
       icon: "fas fa-brain",
       iconColor: "text-blue-600",
@@ -329,7 +331,15 @@ export default function Projects() {
                           </Badge>
                         ))}
                       </div>
-                      <div>
+                      <div className="flex gap-4">
+                        {proj.demoUrl && (
+                          <Button
+                            onClick={() => window.open(proj.demoUrl!, "_blank")}
+                            className="bg-green-600 text-white hover:bg-green-700"
+                          >
+                            Try Demo
+                          </Button>
+                        )}
                         {proj.secondaryCTA && (
                           <Button
                             variant="outline"


### PR DESCRIPTION
## Summary
- extend `Project` interface with optional `demoUrl`
- include demo URL for the emotion detection project
- render new "Try Demo" button when `demoUrl` is available

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68719911bb3c83308a3d9d22708a0569